### PR TITLE
Support Sims 3/4 header mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Put simply, this means that you get the benefit of being able to use any format 
 without any performance overhead from dynamic dispatch, as well as being able to implement your
 own arbitrary formats that are still compatible with the same compression algorithms.
 
-More details on the refpack format can be found at [the niotso wiki](http://wiki.niotso.org/RefPack).
-The short explanation is that RefPack is a compression scheme loosely based on LZ77 compression.
+More details on the refpack format can be found at [the niotso wiki](http://wiki.niotso.org/RefPack). The short explanation is that RefPack is a compression scheme loosely based on LZ77 compression.
 
 The [Original Refpack Implementation](http://download.wcnews.com/files/documents/sourcecode/shadowforce/transfer/asommers/mfcapp_src/engine/compress/RefPack.cpp)
 was referenced to ensure proper compatibility
@@ -39,18 +38,19 @@ that implements `std::io::Read` and `std::io::Write`, respectively.
 while `compress` will read in the provided length.
 
 all compression and decompression functions accept one generic argument constrained to the
-[Format](https://docs.rs/refpack/latest/refpack/format/trait.Format.html) trait.
-Implementations should be a unit or "unconstructable"
+[Format](https://docs.rs/refpack/latest/refpack/format/trait.Format.html) trait. Implementations should be a unit or "unconstructable"
 (one inaccessible `()` member to prevent construction), and define a pair of how to interpret
+
 
 ### Implementations
 
-| Format                                                                           | Games                                    | Control   | Header    |
-|----------------------------------------------------------------------------------|------------------------------------------|-----------|-----------|
+| Format | Games | Control | Header |
+|--------|-------|---------|--------|
 | [Reference](https://docs.rs/refpack/latest/refpack/format/struct.Reference.html) | Various 90s Origin Software and EA games | Reference | Reference |
-| [TheSims12](https://docs.rs/refpack/latest/refpack/format/struct.TheSims12.html) | The Sims, The Sims Online, The Sims 2    | Reference | Maxis     |
-| [Simcity4](https://docs.rs/refpack/latest/refpack/format/struct.Simcity4.html)   | Simcity 4                                | Simcity4  | Maxis     |
-| [TheSims34](https://docs.rs/refpack/latest/refpack/format/struct.TheSims34.html) | The Sims 3, The Sims 4                   | Reference | Maxis2    |
+| [TheSims12](https://docs.rs/refpack/latest/refpack/format/struct.TheSims12.html) | The Sims, The Sims Online, The Sims 2 | Reference | Maxis |
+| [Simcity4](https://docs.rs/refpack/latest/refpack/format/struct.Simcity4.html) | Simcity 4 | Simcity4 | Maxis |
+| [TheSims34](https://docs.rs/refpack/latest/refpack/format/struct.TheSims34.html) | The Sims 3, The Sims 4 | Reference | Maxis2 |
+
 
 #### Example
 
@@ -59,11 +59,9 @@ use std::io::Cursor;
 use std::io::Seek;
 use refpack::format::Reference;
 
-fn main() {
-    let mut source_reader = Cursor::new(b"Hello World!".to_vec());
-    let mut out_buf = Cursor::new(vec![]);
-    refpack::compress::<Reference>(source_reader.get_ref().len(), &mut source_reader, &mut out_buf).unwrap();
-}
+let mut source_reader = Cursor::new(b"Hello World!".to_vec());
+let mut out_buf = Cursor::new(vec![]);
+refpack::compress::<Reference>(source_reader.get_ref().len(), &mut source_reader, &mut out_buf).unwrap();
 ```
 
 The easy variants are `compress_easy` and `decompress_easy`, which take a `&[u8]` and return

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ all compression and decompression functions accept one generic argument constrai
 | [Reference](https://docs.rs/refpack/latest/refpack/format/struct.Reference.html) | Various 90s Origin Software and EA games | Reference | Reference |
 | [TheSims12](https://docs.rs/refpack/latest/refpack/format/struct.TheSims12.html) | The Sims, The Sims Online, The Sims 2 | Reference | Maxis |
 | [Simcity4](https://docs.rs/refpack/latest/refpack/format/struct.Simcity4.html) | Simcity 4 | Simcity4 | Maxis |
-| [TheSims34](https://docs.rs/refpack/latest/refpack/format/struct.TheSims34.html) | The Sims 3, The Sims 4 | Reference | Maxis2 |
+| [TheSims34](https://docs.rs/refpack/latest/refpack/format/struct.TheSims34.html) | The Sims 3, The Sims 4 | Reference | SimEA |
 
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # refpack-rs
+
 [![Rust Build and Test](https://github.com/actioninja/refpack-rs/actions/workflows/check-and-test.yml/badge.svg)](https://github.com/actioninja/refpack-rs/actions/workflows/check-and-test.yml)
 ![docs.rs](https://img.shields.io/docsrs/refpack)
 ![Crates.io](https://img.shields.io/crates/v/refpack)
@@ -20,7 +21,8 @@ Put simply, this means that you get the benefit of being able to use any format 
 without any performance overhead from dynamic dispatch, as well as being able to implement your
 own arbitrary formats that are still compatible with the same compression algorithms.
 
-More details on the refpack format can be found at [the niotso wiki](http://wiki.niotso.org/RefPack). The short explanation is that RefPack is a compression scheme loosely based on LZ77 compression.
+More details on the refpack format can be found at [the niotso wiki](http://wiki.niotso.org/RefPack).
+The short explanation is that RefPack is a compression scheme loosely based on LZ77 compression.
 
 The [Original Refpack Implementation](http://download.wcnews.com/files/documents/sourcecode/shadowforce/transfer/asommers/mfcapp_src/engine/compress/RefPack.cpp)
 was referenced to ensure proper compatibility
@@ -37,18 +39,18 @@ that implements `std::io::Read` and `std::io::Write`, respectively.
 while `compress` will read in the provided length.
 
 all compression and decompression functions accept one generic argument constrained to the
-[Format](https://docs.rs/refpack/latest/refpack/format/trait.Format.html) trait. Implementations should be a unit or "unconstructable"
+[Format](https://docs.rs/refpack/latest/refpack/format/trait.Format.html) trait.
+Implementations should be a unit or "unconstructable"
 (one inaccessible `()` member to prevent construction), and define a pair of how to interpret
-
 
 ### Implementations
 
-| Format | Games | Control | Header |
-|--------|-------|---------|--------|
+| Format                                                                           | Games                                    | Control   | Header    |
+|----------------------------------------------------------------------------------|------------------------------------------|-----------|-----------|
 | [Reference](https://docs.rs/refpack/latest/refpack/format/struct.Reference.html) | Various 90s Origin Software and EA games | Reference | Reference |
-| [TheSims12](https://docs.rs/refpack/latest/refpack/format/struct.TheSims12.html) | The Sims, The Sims Online, The Sims 2 | Reference | Maxis |
-| [Simcity4](https://docs.rs/refpack/latest/refpack/format/struct.Simcity4.html) | Simcity 4 | Simcity4 | Maxis |
-
+| [TheSims12](https://docs.rs/refpack/latest/refpack/format/struct.TheSims12.html) | The Sims, The Sims Online, The Sims 2    | Reference | Maxis     |
+| [Simcity4](https://docs.rs/refpack/latest/refpack/format/struct.Simcity4.html)   | Simcity 4                                | Simcity4  | Maxis     |
+| [TheSims34](https://docs.rs/refpack/latest/refpack/format/struct.TheSims34.html) | The Sims 3, The Sims 4                   | Reference | Maxis2    |
 
 #### Example
 
@@ -57,9 +59,11 @@ use std::io::Cursor;
 use std::io::Seek;
 use refpack::format::Reference;
 
-let mut source_reader = Cursor::new(b"Hello World!".to_vec());
-let mut out_buf = Cursor::new(vec![]);
-refpack::compress::<Reference>(source_reader.get_ref().len(), &mut source_reader, &mut out_buf).unwrap();
+fn main() {
+    let mut source_reader = Cursor::new(b"Hello World!".to_vec());
+    let mut out_buf = Cursor::new(vec![]);
+    refpack::compress::<Reference>(source_reader.get_ref().len(), &mut source_reader, &mut out_buf).unwrap();
+}
 ```
 
 The easy variants are `compress_easy` and `decompress_easy`, which take a `&[u8]` and return

--- a/src/data/compression.rs
+++ b/src/data/compression.rs
@@ -223,7 +223,7 @@ pub fn compress<F: Format>(
 
     let controls = encode_stream::<F>(reader, length)?;
 
-    let header_length = F::HeaderMode::LENGTH;
+    let header_length = F::HeaderMode::length(length);
 
     let header_position = writer.stream_position()?;
     let data_start_pos = writer.seek(SeekFrom::Current(header_length as i64))?;

--- a/src/data/control/mode/reference.rs
+++ b/src/data/control/mode/reference.rs
@@ -161,9 +161,9 @@ impl Reference {
         let length_adjusted = length - 3;
         let offset_adjusted = offset - 1;
 
-        let first = (((offset_adjusted & 0b0000_0011_0000_0000) >> 3) as u8
+        let first = ((offset_adjusted & 0b0000_0011_0000_0000) >> 3) as u8
             | (length_adjusted & 0b0000_0111) << 2
-            | literal & 0b0000_0011) as u8;
+            | literal & 0b0000_0011;
         let second = (offset_adjusted & 0b0000_0000_1111_1111) as u8;
 
         writer.write_u8(first)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     /// Error for when no input is provided to a compressor function
     #[error("No input provided to compression")]
     EmptyInput,
+    /// Error that occurs when a flag was set in the header flags that is not supported
+    #[error("Unknown flag was set in compression header `{0:08b}`")]
+    BadFlags(u8),
     /// Error indicating that the header failed to read the magic where it expected it. Location
     /// depends on the exact implementation.
     /// u16: What was read instead of the magic value

--- a/src/format.rs
+++ b/src/format.rs
@@ -10,7 +10,7 @@
 //!
 use crate::data::control::mode::{Reference as ReferenceControl, Simcity4 as Simcity4Control};
 use crate::data::control::Mode as ControlMode;
-use crate::header::mode::{Maxis, SimEA, Mode as HeaderMode, Reference as ReferenceHeader};
+use crate::header::mode::{Maxis, Mode as HeaderMode, Reference as ReferenceHeader, SimEA};
 
 /// Trait that represents a pair of Header Modes and Control Modes that define a compression format.
 ///

--- a/src/format.rs
+++ b/src/format.rs
@@ -10,7 +10,7 @@
 //!
 use crate::data::control::mode::{Reference as ReferenceControl, Simcity4 as Simcity4Control};
 use crate::data::control::Mode as ControlMode;
-use crate::header::mode::{Maxis, Maxis2, Mode as HeaderMode, Reference as ReferenceHeader};
+use crate::header::mode::{Maxis, SimEA, Mode as HeaderMode, Reference as ReferenceHeader};
 
 /// Trait that represents a pair of Header Modes and Control Modes that define a compression format.
 ///
@@ -72,7 +72,7 @@ impl Format for Simcity4 {
 }
 
 /// Format utilized by Simcity 4.
-/// - Uses new [Maxis2](crate::header::mode::Maxis2) header
+/// - Uses new [Maxis2](crate::header::mode::SimEA) header
 /// - Standard control codes ([Reference](crate::data::control::mode::Reference))
 pub struct TheSims34 {
     // trick to prevent struct from ever being constructed. These are "markers" intended to be used
@@ -81,6 +81,6 @@ pub struct TheSims34 {
 }
 
 impl Format for TheSims34 {
-    type HeaderMode = Maxis2;
+    type HeaderMode = SimEA;
     type ControlMode = ReferenceControl;
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -10,7 +10,7 @@
 //!
 use crate::data::control::mode::{Reference as ReferenceControl, Simcity4 as Simcity4Control};
 use crate::data::control::Mode as ControlMode;
-use crate::header::mode::{Maxis, Mode as HeaderMode, Reference as ReferenceHeader};
+use crate::header::mode::{Maxis, Maxis2, Mode as HeaderMode, Reference as ReferenceHeader};
 
 /// Trait that represents a pair of Header Modes and Control Modes that define a compression format.
 ///
@@ -69,4 +69,18 @@ pub struct Simcity4 {
 impl Format for Simcity4 {
     type HeaderMode = Maxis;
     type ControlMode = Simcity4Control;
+}
+
+/// Format utilized by Simcity 4.
+/// - Uses new [Maxis2](crate::header::mode::Maxis2) header
+/// - Standard control codes ([Reference](crate::data::control::mode::Reference))
+pub struct TheSims34 {
+    // trick to prevent struct from ever being constructed. These are "markers" intended to be used
+    // as generic arguments rather than data structs
+    _private: (),
+}
+
+impl Format for TheSims34 {
+    type HeaderMode = Maxis2;
+    type ControlMode = ReferenceControl;
 }

--- a/src/header/mode/maxis.rs
+++ b/src/header/mode/maxis.rs
@@ -28,7 +28,9 @@ pub struct Maxis {
 pub const FLAGS: u8 = 0x10;
 
 impl Mode for Maxis {
-    const LENGTH: usize = 9;
+    fn length(_decompressed_size: usize) -> usize {
+        9
+    }
 
     fn read<R: Read + Seek>(reader: &mut R) -> RefPackResult<Header> {
         let compressed_length_prewrap = reader.read_u32::<LittleEndian>()?;

--- a/src/header/mode/maxis.rs
+++ b/src/header/mode/maxis.rs
@@ -39,7 +39,10 @@ impl Mode for Maxis {
         } else {
             Some(compressed_length_prewrap)
         };
-        let _flags = reader.read_u8()?;
+        let flags = reader.read_u8()?;
+        if flags != FLAGS {
+            return Err(RefPackError::BadFlags(flags));
+        }
         let magic = reader.read_u8()?;
         if magic != header::MAGIC {
             return Err(RefPackError::BadMagic(magic));

--- a/src/header/mode/maxis2.rs
+++ b/src/header/mode/maxis2.rs
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////////
+// This Source Code Form is subject to the terms of the Mozilla Public         /
+// License, v. 2.0. If a copy of the MPL was not distributed with this         /
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.                   /
+//                                                                             /
+////////////////////////////////////////////////////////////////////////////////
+
+use std::io::{Read, Seek, Write};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::header::mode::Mode;
+use crate::header::Header;
+use crate::{header, RefPackError, RefPackResult};
+
+/// Header used by many Maxis and SimEA games
+/// Exactly the same as [Maxis](crate::header::mode::Maxis) but without the compressed length u32
+///
+/// ## Structure
+/// - u8: Flags field
+/// - Magic Number: 0xFB
+/// - Big Endian u24/u32: Decompressed Length
+pub struct Maxis2 {
+    _private: (),
+}
+
+/// The decompressed length flag
+/// Taken from http://simswiki.info/wiki.php?title=Sims_3:DBPF/Compression#Compression_Types
+enum Flags {
+    Little = 0x10,
+    LittleRestricted = 0x40,
+    Big = 0x80,
+}
+
+impl Mode for Maxis2 {
+    const LENGTH: usize = 6;
+
+    fn read<R: Read + Seek>(reader: &mut R) -> RefPackResult<Header> {
+        let flags = match reader.read_u8()? {
+            x if x == Flags::Little as u8 => Flags::Little,
+            x if x == Flags::LittleRestricted as u8 => Flags::LittleRestricted,
+            x if x == Flags::Big as u8 => Flags::Big,
+            x => return Err(RefPackError::BadMagic(x)),
+        };
+        let magic = reader.read_u8()?;
+        if magic != header::MAGIC {
+            return Err(RefPackError::BadMagic(magic));
+        }
+        //Inexplicably this weird three byte number is stored Big Endian
+        let decompressed_length = match flags {
+            Flags::Little | Flags::LittleRestricted => reader.read_u24::<BigEndian>()?,
+            Flags::Big => reader.read_u32::<BigEndian>()?,
+        };
+        Ok(Header {
+            decompressed_length,
+            compressed_length: None,
+        })
+    }
+
+    fn write<W: Write + Seek>(header: Header, writer: &mut W) -> RefPackResult<()> {
+        let big_decompressed = header.decompressed_length > 0xFF_FF_FF;
+        writer.write_u8(if big_decompressed { Flags::Big } else { Flags::Little } as u8)?;
+        writer.write_u8(header::MAGIC)?;
+        if big_decompressed {
+            writer.write_u32::<BigEndian>(header.decompressed_length)?;
+        } else {
+            writer.write_u24::<BigEndian>(header.decompressed_length)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Cursor;
+
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+
+    use super::*;
+    use crate::header::Header;
+
+    #[proptest]
+    fn symmetrical_read_write(
+        #[any(decompressed_limit = 16_777_214 * 2, compressed_limit = None)] header: Header,
+    ) {
+        let mut write_buf = vec![];
+        let mut write_cur = Cursor::new(&mut write_buf);
+        header.write::<Maxis2>(&mut write_cur).unwrap();
+
+        prop_assert_eq!(write_buf.len(), Maxis2::LENGTH);
+
+        let mut read_cur = Cursor::new(&mut write_buf);
+        let got = Header::read::<Maxis2>(&mut read_cur).unwrap();
+
+        prop_assert_eq!(header, got);
+    }
+}

--- a/src/header/mode/maxis2.rs
+++ b/src/header/mode/maxis2.rs
@@ -65,7 +65,11 @@ impl Mode for Maxis2 {
 
     fn write<W: Write + Seek>(header: Header, writer: &mut W) -> RefPackResult<()> {
         let big_decompressed = header.decompressed_length > 0xFF_FF_FF;
-        writer.write_u8(if big_decompressed { Flags::Big } else { Flags::Little } as u8)?;
+        writer.write_u8(if big_decompressed {
+            Flags::Big
+        } else {
+            Flags::Little
+        } as u8)?;
         writer.write_u8(header::MAGIC)?;
         if big_decompressed {
             writer.write_u32::<BigEndian>(header.decompressed_length)?;
@@ -94,7 +98,10 @@ mod test {
         let mut write_cur = Cursor::new(&mut write_buf);
         header.write::<Maxis2>(&mut write_cur).unwrap();
 
-        prop_assert_eq!(write_buf.len(), Maxis2::length(header.decompressed_length as usize));
+        prop_assert_eq!(
+            write_buf.len(),
+            Maxis2::length(header.decompressed_length as usize)
+        );
 
         let mut read_cur = Cursor::new(&mut write_buf);
         let got = Header::read::<Maxis2>(&mut read_cur).unwrap();

--- a/src/header/mode/maxis2.rs
+++ b/src/header/mode/maxis2.rs
@@ -33,7 +33,13 @@ enum Flags {
 }
 
 impl Mode for Maxis2 {
-    const LENGTH: usize = 6;
+    fn length(decompressed_size: usize) -> usize {
+        if decompressed_size > 0xFF_FF_FF {
+            6
+        } else {
+            5
+        }
+    }
 
     fn read<R: Read + Seek>(reader: &mut R) -> RefPackResult<Header> {
         let flags = match reader.read_u8()? {
@@ -88,7 +94,7 @@ mod test {
         let mut write_cur = Cursor::new(&mut write_buf);
         header.write::<Maxis2>(&mut write_cur).unwrap();
 
-        prop_assert_eq!(write_buf.len(), Maxis2::LENGTH);
+        prop_assert_eq!(write_buf.len(), Maxis2::length(header.decompressed_length as usize));
 
         let mut read_cur = Cursor::new(&mut write_buf);
         let got = Header::read::<Maxis2>(&mut read_cur).unwrap();

--- a/src/header/mode/mod.rs
+++ b/src/header/mode/mod.rs
@@ -7,11 +7,13 @@
 
 //! possible modes to use for header encoding and decoding
 mod maxis;
+mod maxis2;
 mod reference;
 
 use std::io::{Read, Seek, Write};
 
 pub use maxis::Maxis;
+pub use maxis2::Maxis2;
 pub use reference::Reference;
 
 use crate::header::Header;

--- a/src/header/mode/mod.rs
+++ b/src/header/mode/mod.rs
@@ -7,13 +7,13 @@
 
 //! possible modes to use for header encoding and decoding
 mod maxis;
-mod maxis2;
+mod sim_ea;
 mod reference;
 
 use std::io::{Read, Seek, Write};
 
 pub use maxis::Maxis;
-pub use maxis2::Maxis2;
+pub use sim_ea::SimEA;
 pub use reference::Reference;
 
 use crate::header::Header;

--- a/src/header/mode/mod.rs
+++ b/src/header/mode/mod.rs
@@ -7,14 +7,14 @@
 
 //! possible modes to use for header encoding and decoding
 mod maxis;
-mod sim_ea;
 mod reference;
+mod sim_ea;
 
 use std::io::{Read, Seek, Write};
 
 pub use maxis::Maxis;
-pub use sim_ea::SimEA;
 pub use reference::Reference;
+pub use sim_ea::SimEA;
 
 use crate::header::Header;
 use crate::RefPackResult;

--- a/src/header/mode/mod.rs
+++ b/src/header/mode/mod.rs
@@ -30,7 +30,7 @@ use crate::RefPackResult;
 /// fed in to read and then back out of write should yield the same result.
 pub trait Mode {
     /// Length of the header, used by some parsing
-    const LENGTH: usize;
+    fn length(decompressed_size: usize) -> usize;
 
     /// Reads from a `Read + Seek` reader and attempts to parse a header at the current position.
     /// # Errors

--- a/src/header/mode/reference.rs
+++ b/src/header/mode/reference.rs
@@ -24,7 +24,9 @@ pub struct Reference {
 }
 
 impl Mode for Reference {
-    const LENGTH: usize = 4;
+    fn length(_decompressed_size: usize) -> usize {
+        4
+    }
 
     fn read<R: Read + Seek>(reader: &mut R) -> RefPackResult<Header> {
         let decompressed_length = reader.read_u32::<LittleEndian>()?;

--- a/src/header/mode/sim_ea.rs
+++ b/src/header/mode/sim_ea.rs
@@ -20,7 +20,7 @@ use crate::{header, RefPackError, RefPackResult};
 /// - u8: Flags field
 /// - Magic Number: 0xFB
 /// - Big Endian u24/u32: Decompressed Length
-pub struct Maxis2 {
+pub struct SimEA {
     _private: (),
 }
 
@@ -32,7 +32,7 @@ enum Flags {
     Big = 0x80,
 }
 
-impl Mode for Maxis2 {
+impl Mode for SimEA {
     fn length(decompressed_size: usize) -> usize {
         if decompressed_size > 0xFF_FF_FF {
             6
@@ -96,15 +96,15 @@ mod test {
     ) {
         let mut write_buf = vec![];
         let mut write_cur = Cursor::new(&mut write_buf);
-        header.write::<Maxis2>(&mut write_cur).unwrap();
+        header.write::<SimEA>(&mut write_cur).unwrap();
 
         prop_assert_eq!(
             write_buf.len(),
-            Maxis2::length(header.decompressed_length as usize)
+            SimEA::length(header.decompressed_length as usize)
         );
 
         let mut read_cur = Cursor::new(&mut write_buf);
-        let got = Header::read::<Maxis2>(&mut read_cur).unwrap();
+        let got = Header::read::<SimEA>(&mut read_cur).unwrap();
 
         prop_assert_eq!(header, got);
     }

--- a/src/header/mode/sim_ea.rs
+++ b/src/header/mode/sim_ea.rs
@@ -11,8 +11,8 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::header::mode::Mode;
 use crate::header::Header;
-use crate::{header, RefPackError, RefPackResult};
 use crate::RefPackError::BadFlags;
+use crate::{header, RefPackError, RefPackResult};
 
 /// Header used by many Maxis and SimEA games
 /// The same as [Maxis](crate::header::mode::Maxis) but without the compressed length u32,
@@ -50,9 +50,9 @@ impl Flags {
     }
 
     fn write(self) -> u8 {
-        (self.big_decompressed as u8) << 7 |
-            (self.restricted as u8) << 6 |
-            (self.compressed_size_present as u8)
+        (self.big_decompressed as u8) << 7
+            | (self.restricted as u8) << 6
+            | (self.compressed_size_present as u8)
     }
 }
 
@@ -85,11 +85,14 @@ impl Mode for SimEA {
 
     fn write<W: Write + Seek>(header: Header, writer: &mut W) -> RefPackResult<()> {
         let big_decompressed = header.decompressed_length > 0xFF_FF_FF;
-        writer.write_u8(Flags {
-            big_decompressed,
-            restricted: false,
-            compressed_size_present: false,
-        }.write())?;
+        writer.write_u8(
+            Flags {
+                big_decompressed,
+                restricted: false,
+                compressed_size_present: false,
+            }
+            .write(),
+        )?;
         writer.write_u8(header::MAGIC)?;
         if big_decompressed {
             writer.write_u32::<BigEndian>(header.decompressed_length)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //! | [Reference](crate::format::Reference) | Various 90s Origin Software and EA games | [Reference](crate::data::control::mode::Reference) | [Reference](crate::header::mode::Reference) |
 //! | [TheSims12](crate::format::TheSims12) | The Sims, The Sims Online, The Sims 2 | [Reference](crate::data::control::mode::Reference) | [Maxis](crate::header::mode::Maxis) |
 //! | [Simcity4](crate::format::Simcity4) | Simcity 4 | [Simcity4](crate::data::control::mode::Simcity4) | [Maxis](crate::header::mode::Maxis) |
+//! | [TheSims34](crate::format::TheSims34) | The Sims 3, The Sims 4 | [Reference](crate::data::control::mode::Reference) | [Maxis2](crate::header::mode::Maxis2) |
 //!
 //!
 //! ### Example
@@ -89,20 +90,18 @@ pub use crate::data::compression::{compress, easy_compress};
 pub use crate::data::decompression::{decompress, easy_decompress};
 pub use crate::error::{Error as RefPackError, Result as RefPackResult};
 
-
 #[cfg(test)]
 mod test {
     use proptest::collection::vec;
     use proptest::num::u8;
     use proptest::prop_assert_eq;
     use test_strategy::proptest;
-    use crate::{easy_compress, easy_decompress};
+
     use crate::format::{Reference, Simcity4, TheSims12, TheSims34};
+    use crate::{easy_compress, easy_decompress};
 
     #[proptest]
-    fn reference_symmetrical_read_write(
-        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
-
+    fn reference_symmetrical_read_write(#[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
         let compressed = easy_compress::<Reference>(&data).unwrap();
 
         let got = easy_decompress::<Reference>(&compressed).unwrap();
@@ -111,8 +110,7 @@ mod test {
     }
 
     #[proptest]
-    fn sims12_symmetrical_read_write(
-        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+    fn sims12_symmetrical_read_write(#[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
         let compressed = easy_compress::<TheSims12>(&data).unwrap();
 
         let got = easy_decompress::<TheSims12>(&compressed).unwrap();
@@ -121,8 +119,7 @@ mod test {
     }
 
     #[proptest]
-    fn simcity4_symmetrical_read_write(
-        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+    fn simcity4_symmetrical_read_write(#[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
         let compressed = easy_compress::<Simcity4>(&data).unwrap();
 
         let got = easy_decompress::<Simcity4>(&compressed).unwrap();
@@ -133,7 +130,8 @@ mod test {
     #[proptest]
     fn sims34_symmetrical_read_write(
         // this should include inputs of > 16mb, but testing those inputs is extremely slow
-        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>,
+    ) {
         let compressed = easy_compress::<TheSims34>(&data).unwrap();
 
         let got = easy_decompress::<TheSims34>(&compressed).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,3 +88,55 @@ pub mod header;
 pub use crate::data::compression::{compress, easy_compress};
 pub use crate::data::decompression::{decompress, easy_decompress};
 pub use crate::error::{Error as RefPackError, Result as RefPackResult};
+
+
+#[cfg(test)]
+mod test {
+    use proptest::collection::vec;
+    use proptest::num::u8;
+    use proptest::prop_assert_eq;
+    use test_strategy::proptest;
+    use crate::{easy_compress, easy_decompress, format};
+    use crate::format::{Reference, Simcity4, TheSims12, TheSims34};
+
+    #[proptest]
+    fn reference_symmetrical_read_write(
+        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+
+        let compressed = easy_compress::<Reference>(&data).unwrap();
+
+        let got = easy_decompress::<Reference>(&compressed).unwrap();
+
+        prop_assert_eq!(data, got);
+    }
+
+    #[proptest]
+    fn sims12_symmetrical_read_write(
+        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+        let compressed = easy_compress::<TheSims12>(&data).unwrap();
+
+        let got = easy_decompress::<TheSims12>(&compressed).unwrap();
+
+        prop_assert_eq!(data, got);
+    }
+
+    #[proptest]
+    fn simcity4_symmetrical_read_write(
+        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+        let compressed = easy_compress::<Simcity4>(&data).unwrap();
+
+        let got = easy_decompress::<Simcity4>(&compressed).unwrap();
+
+        prop_assert_eq!(data, got);
+    }
+
+    #[proptest]
+    fn sims34_symmetrical_read_write(
+        #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
+        let compressed = easy_compress::<TheSims34>(&data).unwrap();
+
+        let got = easy_decompress::<TheSims34>(&compressed).unwrap();
+
+        prop_assert_eq!(data, got);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! | [Reference](crate::format::Reference) | Various 90s Origin Software and EA games | [Reference](crate::data::control::mode::Reference) | [Reference](crate::header::mode::Reference) |
 //! | [TheSims12](crate::format::TheSims12) | The Sims, The Sims Online, The Sims 2 | [Reference](crate::data::control::mode::Reference) | [Maxis](crate::header::mode::Maxis) |
 //! | [Simcity4](crate::format::Simcity4) | Simcity 4 | [Simcity4](crate::data::control::mode::Simcity4) | [Maxis](crate::header::mode::Maxis) |
-//! | [TheSims34](crate::format::TheSims34) | The Sims 3, The Sims 4 | [Reference](crate::data::control::mode::Reference) | [Maxis2](crate::header::mode::Maxis2) |
+//! | [TheSims34](crate::format::TheSims34) | The Sims 3, The Sims 4 | [Reference](crate::data::control::mode::Reference) | [SimEA](crate::header::mode::SimEA) |
 //!
 //!
 //! ### Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ mod test {
     use proptest::num::u8;
     use proptest::prop_assert_eq;
     use test_strategy::proptest;
-    use crate::{easy_compress, easy_decompress, format};
+    use crate::{easy_compress, easy_decompress};
     use crate::format::{Reference, Simcity4, TheSims12, TheSims34};
 
     #[proptest]
@@ -132,6 +132,7 @@ mod test {
 
     #[proptest]
     fn sims34_symmetrical_read_write(
+        // this should include inputs of > 16mb, but testing those inputs is extremely slow
         #[strategy(vec(u8::ANY, 1..1000))] data: Vec<u8>) {
         let compressed = easy_compress::<TheSims34>(&data).unwrap();
 


### PR DESCRIPTION
The new maxis header mode is the same as Maxis, with the removal of the compressed size u32, and the addition of more flags for decompressed int size / feature flags.
Reference: [Sims 3 Compression](http://simswiki.info/wiki.php?title=Sims_3:DBPF/Compression)

I have found no evidence of these flags used in any Sims 2 packages (these use the old maxis header, so always 0x10FB).

With this a change had to be made to the header length interface to be a function (with decompressed size as an argument) instead of a constant.

I'm not really sure about calling the new header mode 'Maxis2', it works well enough as an internal implementation detail, but suggestions are welcome.

I've also added some integration tests to verify that writing headers and data works in combination with each other for all formats.