### PR TITLE
Improve decompress performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 Cargo.lock
+/benches/bench_files
 
 /.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,9 @@ refpack-sys = { git = "https://github.com/actioninja/refpack-sys.git" }
 name = "synthetic_performance"
 harness = false
 
+[[bench]]
+name = "control"
+harness = false
+
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ refpack-sys = { git = "https://github.com/actioninja/refpack-sys.git" }
 [[bench]]
 name = "synthetic_performance"
 harness = false
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 criterion = "0.4"
+criterion-cycles-per-byte = "0.4"
 paste = "1.0"
 proptest = "1.0"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ byteorder = "1.4"
 thiserror = "1.0"
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = { version = "0.4", features = ["html_reports"] }
 criterion-cycles-per-byte = "0.4"
 paste = "1.0"
 proptest = "1.0"
 rand = "0.8"
 test-strategy = "0.3"
-refpack-sys = { git = "https://github.com/actioninja/refpack-sys.git"}
+refpack-sys = { git = "https://github.com/actioninja/refpack-sys.git" }
 
 [[bench]]
 name = "synthetic_performance"

--- a/benches/control.rs
+++ b/benches/control.rs
@@ -1,0 +1,70 @@
+use std::io::Cursor;
+use criterion::{Criterion, criterion_group, criterion_main, Throughput};
+use criterion::measurement::WallTime;
+use refpack::data::control::{Command, Control, Mode};
+use refpack::easy_decompress;
+use refpack::format::{Format, Reference};
+use refpack::header::Header;
+use refpack::header::mode::Mode as HeaderMode;
+
+const CONST_BENCH_LENGTH: usize = 8096;
+
+fn repeating_short_control_vec<M: Mode>(repeats: usize) -> Vec<Control> {
+    let mut ret = vec![Control::new_literal_block::<M>(&[0; 4])];
+    ret.append(&mut vec![
+        Control::new(Command::new::<M>(1, 1, 0),
+                     vec![]);
+        repeats]);
+    ret.push(Control::new_stop::<M>(&[]));
+    ret
+}
+
+fn repeating_short_control_data<F: Format>(repeats: usize) -> Vec<u8> {
+    let mut writer = Cursor::new(vec![]);
+
+    let controls = repeating_short_control_vec::<F::ControlMode>(repeats);
+
+    let header_length = F::HeaderMode::LENGTH;
+
+    writer.set_position(header_length as u64);
+
+    for control in controls {
+        control.write::<F::ControlMode>(&mut writer).unwrap();
+    }
+
+    let data_end_pos = writer.position();
+
+    let compression_length = data_end_pos;
+
+    let header = Header {
+        compressed_length: Some(compression_length as u32),
+        decompressed_length: (repeats + 1) as u32,
+    };
+
+    writer.set_position(0);
+
+    header.write::<F::HeaderMode>(&mut writer).unwrap();
+
+    writer.into_inner()
+}
+
+fn repeating_short_control_bench(c: &mut Criterion<WallTime>) {
+    let mut group = c.benchmark_group("Repeating short control copy 1 byte".to_string());
+
+    group.throughput(Throughput::Bytes(CONST_BENCH_LENGTH as u64));
+
+    let input = repeating_short_control_data::<Reference>(CONST_BENCH_LENGTH);
+
+    group.bench_with_input("easy_decompress", &input, |b, i| {
+        b.iter(|| easy_decompress::<Reference>(i))
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = repeating_short_control_bench
+);
+criterion_main!(benches);

--- a/benches/control.rs
+++ b/benches/control.rs
@@ -1,20 +1,21 @@
 use std::io::Cursor;
-use criterion::{Criterion, criterion_group, criterion_main, Throughput};
+
 use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use refpack::data::control::{Command, Control, Mode};
 use refpack::easy_decompress;
 use refpack::format::{Format, Reference};
-use refpack::header::Header;
 use refpack::header::mode::Mode as HeaderMode;
+use refpack::header::Header;
 
 const CONST_BENCH_LENGTH: usize = 8096;
 
 fn repeating_short_control_vec<M: Mode>(repeats: usize) -> Vec<Control> {
     let mut ret = vec![Control::new_literal_block::<M>(&[0; 4])];
     ret.append(&mut vec![
-        Control::new(Command::new::<M>(1, 1, 0),
-                     vec![]);
-        repeats]);
+        Control::new(Command::new::<M>(1, 1, 0), vec![]);
+        repeats
+    ]);
     ret.push(Control::new_stop::<M>(&[]));
     ret
 }
@@ -24,7 +25,7 @@ fn repeating_short_control_data<F: Format>(repeats: usize) -> Vec<u8> {
 
     let controls = repeating_short_control_vec::<F::ControlMode>(repeats);
 
-    let header_length = F::HeaderMode::LENGTH;
+    let header_length = F::HeaderMode::length(repeats + 1);
 
     writer.set_position(header_length as u64);
 

--- a/benches/download_corpus_bench.sh
+++ b/benches/download_corpus_bench.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# from https://github.com/PSeitz/lz4_flex/blob/main/benchmarks/download_corpus_bench.sh
+
+mkdir bench_files
+cd bench_files || exit
+wget https://sun.aei.polsl.pl//~sdeor/corpus/silesia.zip
+unzip ./silesia.zip
+rm silesia.zip
+

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -34,6 +34,10 @@ fn random_increasing_vecs(num: usize, increase_interval: usize) -> Vec<Vec<u8>> 
     .collect()
 }
 
+fn repeating_vec(num: usize) -> Vec<u8> {
+    (0..=255).cycle().take(num).collect()
+}
+
 fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     let size = input_vec.len();
     group.bench_with_input(format!("easy_compress ({size})"), &input_vec, |b, i| {
@@ -118,8 +122,27 @@ fn random_increasing_data_sets_bench(c: &mut Criterion) {
     group.finish()
 }
 
+fn repeating_increasing_data_sets_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Repeating Input Data Increasing");
+
+    for size in [
+        CONST_BENCH_LENGTH,
+        CONST_BENCH_LENGTH * 2,
+        CONST_BENCH_LENGTH * 4,
+        CONST_BENCH_LENGTH * 8,
+        CONST_BENCH_LENGTH * 16,
+        CONST_BENCH_LENGTH * 32,
+    ] {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        let random_input = repeating_vec(size);
+        bench_set(&mut group, &random_input);
+    }
+    group.finish()
+}
+
 fn files_bench(c: &mut Criterion) {
-    let mut entries = fs::read_dir(".").unwrap()
+    let mut entries = fs::read_dir("benches/bench_files/").unwrap()
         .map(|res| res.unwrap().path())
         .collect::<Vec<_>>();
 
@@ -144,6 +167,7 @@ criterion_group!(
     benches,
     random_data_bench,
     random_increasing_data_sets_bench,
+    repeating_increasing_data_sets_bench,
     files_bench
 );
 criterion_main!(benches);

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -7,6 +7,7 @@
 
 use std::io::Cursor;
 use std::{fs, iter};
+use std::time::Duration;
 
 use criterion::measurement::WallTime;
 use criterion::{
@@ -118,15 +119,20 @@ fn random_increasing_data_sets_bench(c: &mut Criterion) {
 }
 
 fn files_bench(c: &mut Criterion) {
-    for file in fs::read_dir("benches/bench_files/").unwrap() {
-        let file = file.unwrap();
+    let mut entries = fs::read_dir(".").unwrap()
+        .map(|res| res.unwrap().path())
+        .collect::<Vec<_>>();
 
+    entries.sort();
+
+    for file in entries {
         let mut group = c.benchmark_group(format!("File {:?}", file.file_name()));
 
-        let input = fs::read(file.path()).unwrap();
+        let input = fs::read(file).unwrap();
 
         group.throughput(Throughput::Bytes(input.len() as u64));
         group.sample_size(10);
+        group.measurement_time(Duration::from_secs(10));
 
         bench_set(&mut group, &input);
 

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -5,14 +5,15 @@
 //                                                                             /
 ////////////////////////////////////////////////////////////////////////////////
 
+use std::hint::black_box;
 use std::io::Cursor;
 use std::time::Duration;
 use std::{fs, iter};
 
 use criterion::measurement::WallTime;
 use criterion::{
-    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion,
-    SamplingMode, Throughput,
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode,
+    Throughput,
 };
 use rand::prelude::*;
 use refpack::format::Reference;
@@ -44,7 +45,7 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     group.bench_with_input(
         BenchmarkId::new("easy_compress", size),
         &input_vec,
-        |b, i| b.iter(|| easy_compress::<Reference>(black_box(i))),
+        |b, i| b.iter(|| easy_compress::<Reference>(i)),
     );
 
     group.bench_with_input(BenchmarkId::new("compress", size), &input_vec, |b, i| {
@@ -60,7 +61,7 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     group.bench_with_input(
         BenchmarkId::new("easy_decompress", size),
         &compressed,
-        |b, i| b.iter(|| black_box(easy_decompress::<Reference>(black_box(i)))),
+        |b, i| b.iter(|| easy_decompress::<Reference>(i)),
     );
 
     group.bench_with_input(BenchmarkId::new("decompress", size), &compressed, |b, i| {
@@ -77,8 +78,7 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
         |b, i| {
             b.iter(|| {
                 let compressed = easy_compress::<Reference>(i).unwrap();
-                let decompressed = easy_decompress::<Reference>(black_box(&compressed)).unwrap();
-                black_box(decompressed);
+                easy_decompress::<Reference>(black_box(&compressed)).unwrap()
             })
         },
     );

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -147,7 +147,7 @@ fn files_bench(c: &mut Criterion<CyclesPerByte>) {
     entries.sort();
 
     for file in entries {
-        let mut group = c.benchmark_group(format!("File {:?}", file.file_name()));
+        let mut group = c.benchmark_group(format!("File {:?}", file.file_name().unwrap()));
 
         let input = fs::read(file).unwrap();
 

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -5,15 +5,16 @@
 //                                                                             /
 ////////////////////////////////////////////////////////////////////////////////
 
-use std::hint::black_box;
 use std::io::Cursor;
 use std::iter;
 
 use criterion::measurement::WallTime;
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput};
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput,
+};
 use rand::prelude::*;
-use refpack::format::TheSims12;
 use refpack::{compress, decompress, easy_compress, easy_decompress};
+use refpack::format::Reference;
 
 const CONST_BENCH_LENGTH: usize = 8096;
 
@@ -35,21 +36,35 @@ fn random_increasing_vecs(num: usize, increase_interval: usize) -> Vec<Vec<u8>> 
 fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     let size = input_vec.len();
     group.bench_with_input(format!("easy_compress ({size})"), &input_vec, |b, i| {
-        b.iter(|| easy_compress::<TheSims12>(black_box(i)))
+        b.iter(|| easy_compress::<Reference>(black_box(i)))
     });
 
     group.bench_with_input(format!("compress ({size})"), &input_vec, |b, i| {
         b.iter(|| {
             let mut in_buf = Cursor::new(i);
             let mut out_buf = Cursor::new(vec![]);
-            compress::<TheSims12>(size, black_box(&mut in_buf), black_box(&mut out_buf))
+            compress::<Reference>(size, black_box(&mut in_buf), black_box(&mut out_buf))
+        })
+    });
+
+    let compressed = easy_compress::<Reference>(input_vec).unwrap();
+
+    group.bench_with_input(format!("easy_decompress ({size})"), &compressed, |b, i| {
+        b.iter(|| black_box(easy_decompress::<Reference>(black_box(i))))
+    });
+
+    group.bench_with_input(format!("decompress ({size})"), &compressed, |b, i| {
+        b.iter(|| {
+            let mut in_buf = Cursor::new(i);
+            let mut out_buf = Cursor::new(vec![]);
+            decompress::<Reference>(black_box(&mut in_buf), black_box(&mut out_buf))
         })
     });
 
     group.bench_with_input(format!("symmetrical easy ({size})"), &input_vec, |b, i| {
         b.iter(|| {
-            let compressed = easy_compress::<TheSims12>(i).unwrap();
-            let decompressed = easy_decompress::<TheSims12>(black_box(&compressed)).unwrap();
+            let compressed = easy_compress::<Reference>(i).unwrap();
+            let decompressed = easy_decompress::<Reference>(black_box(&compressed)).unwrap();
             black_box(decompressed);
         })
     });
@@ -60,18 +75,21 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
             let mut out_buf = Cursor::new(vec![]);
             let mut final_buf = Cursor::new(vec![]);
 
-            let _ = compress::<TheSims12>(
-                CONST_BENCH_LENGTH,
+            let _ = compress::<Reference>(
+                size,
                 black_box(&mut in_buf),
                 black_box(&mut out_buf),
             );
-            let _ = decompress::<TheSims12>(black_box(&mut out_buf), black_box(&mut final_buf));
+            out_buf.set_position(0);
+            let _ = decompress::<Reference>(black_box(&mut out_buf), black_box(&mut final_buf));
         })
     });
 }
 
 fn random_data_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("Constant Length Random Input Data".to_string());
+
+    group.throughput(Throughput::Bytes(CONST_BENCH_LENGTH as u64));
 
     let constant_input = random_vec(CONST_BENCH_LENGTH);
 

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -6,14 +6,17 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 use std::io::Cursor;
-use std::{fs, iter};
 use std::time::Duration;
+use std::{fs, iter};
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput, BenchmarkId, SamplingMode};
 use criterion::measurement::WallTime;
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion,
+    SamplingMode, Throughput,
+};
 use rand::prelude::*;
-use refpack::{compress, decompress, easy_compress, easy_decompress};
 use refpack::format::Reference;
+use refpack::{compress, decompress, easy_compress, easy_decompress};
 
 const CONST_BENCH_LENGTH: usize = 8096;
 
@@ -28,8 +31,8 @@ fn random_increasing_vecs(num: usize, increase_interval: usize) -> Vec<Vec<u8>> 
         cur_size += increase_interval;
         random_vec(tmp)
     })
-        .take(num)
-        .collect()
+    .take(num)
+    .collect()
 }
 
 fn repeating_vec(num: usize) -> Vec<u8> {
@@ -38,9 +41,11 @@ fn repeating_vec(num: usize) -> Vec<u8> {
 
 fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     let size = input_vec.len();
-    group.bench_with_input(BenchmarkId::new("easy_compress", size), &input_vec, |b, i| {
-        b.iter(|| easy_compress::<Reference>(black_box(i)))
-    });
+    group.bench_with_input(
+        BenchmarkId::new("easy_compress", size),
+        &input_vec,
+        |b, i| b.iter(|| easy_compress::<Reference>(black_box(i))),
+    );
 
     group.bench_with_input(BenchmarkId::new("compress", size), &input_vec, |b, i| {
         b.iter(|| {
@@ -52,9 +57,11 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
 
     let compressed = easy_compress::<Reference>(input_vec).unwrap();
 
-    group.bench_with_input(BenchmarkId::new("easy_decompress", size), &compressed, |b, i| {
-        b.iter(|| black_box(easy_decompress::<Reference>(black_box(i))))
-    });
+    group.bench_with_input(
+        BenchmarkId::new("easy_decompress", size),
+        &compressed,
+        |b, i| b.iter(|| black_box(easy_decompress::<Reference>(black_box(i)))),
+    );
 
     group.bench_with_input(BenchmarkId::new("decompress", size), &compressed, |b, i| {
         b.iter(|| {
@@ -64,13 +71,17 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
         })
     });
 
-    group.bench_with_input(BenchmarkId::new("symmetrical easy", size), &input_vec, |b, i| {
-        b.iter(|| {
-            let compressed = easy_compress::<Reference>(i).unwrap();
-            let decompressed = easy_decompress::<Reference>(black_box(&compressed)).unwrap();
-            black_box(decompressed);
-        })
-    });
+    group.bench_with_input(
+        BenchmarkId::new("symmetrical easy", size),
+        &input_vec,
+        |b, i| {
+            b.iter(|| {
+                let compressed = easy_compress::<Reference>(i).unwrap();
+                let decompressed = easy_decompress::<Reference>(black_box(&compressed)).unwrap();
+                black_box(decompressed);
+            })
+        },
+    );
 
     group.bench_with_input(BenchmarkId::new("symmetrical", size), &input_vec, |b, i| {
         b.iter(|| {
@@ -78,11 +89,7 @@ fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
             let mut out_buf = Cursor::new(vec![]);
             let mut final_buf = Cursor::new(vec![]);
 
-            let _ = compress::<Reference>(
-                size,
-                black_box(&mut in_buf),
-                black_box(&mut out_buf),
-            );
+            let _ = compress::<Reference>(size, black_box(&mut in_buf), black_box(&mut out_buf));
             out_buf.set_position(0);
             let _ = decompress::<Reference>(black_box(&mut out_buf), black_box(&mut final_buf));
         })
@@ -140,7 +147,8 @@ fn repeating_increasing_data_sets_bench(c: &mut Criterion<WallTime>) {
 }
 
 fn files_bench(c: &mut Criterion<WallTime>) {
-    let mut entries = fs::read_dir("benches/bench_files/").unwrap()
+    let mut entries = fs::read_dir("benches/bench_files/")
+        .unwrap()
         .map(|res| res.unwrap().path())
         .collect::<Vec<_>>();
 

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -6,7 +6,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 use std::io::Cursor;
-use std::iter;
+use std::{fs, iter};
 
 use criterion::measurement::WallTime;
 use criterion::{
@@ -117,9 +117,27 @@ fn random_increasing_data_sets_bench(c: &mut Criterion) {
     group.finish()
 }
 
+fn files_bench(c: &mut Criterion) {
+    for file in fs::read_dir("benches/bench_files/").unwrap() {
+        let file = file.unwrap();
+
+        let mut group = c.benchmark_group(format!("File {:?}", file.file_name()));
+
+        let input = fs::read(file.path()).unwrap();
+
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.sample_size(10);
+
+        bench_set(&mut group, &input);
+
+        group.finish();
+    }
+}
+
 criterion_group!(
     benches,
     random_data_bench,
-    random_increasing_data_sets_bench
+    random_increasing_data_sets_bench,
+    files_bench
 );
 criterion_main!(benches);

--- a/benches/synthetic_performance.rs
+++ b/benches/synthetic_performance.rs
@@ -9,8 +9,8 @@ use std::io::Cursor;
 use std::{fs, iter};
 use std::time::Duration;
 
-use criterion_cycles_per_byte::CyclesPerByte;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput, BenchmarkId, SamplingMode};
+use criterion::measurement::WallTime;
 use rand::prelude::*;
 use refpack::{compress, decompress, easy_compress, easy_decompress};
 use refpack::format::Reference;
@@ -36,7 +36,7 @@ fn repeating_vec(num: usize) -> Vec<u8> {
     (0..=255).cycle().take(num).collect()
 }
 
-fn bench_set(group: &mut BenchmarkGroup<CyclesPerByte>, input_vec: &[u8]) {
+fn bench_set(group: &mut BenchmarkGroup<WallTime>, input_vec: &[u8]) {
     let size = input_vec.len();
     group.bench_with_input(BenchmarkId::new("easy_compress", size), &input_vec, |b, i| {
         b.iter(|| easy_compress::<Reference>(black_box(i)))
@@ -89,7 +89,7 @@ fn bench_set(group: &mut BenchmarkGroup<CyclesPerByte>, input_vec: &[u8]) {
     });
 }
 
-fn random_data_bench(c: &mut Criterion<CyclesPerByte>) {
+fn random_data_bench(c: &mut Criterion<WallTime>) {
     let mut group = c.benchmark_group("Constant Length Random Input Data".to_string());
 
     group.throughput(Throughput::Bytes(CONST_BENCH_LENGTH as u64));
@@ -101,7 +101,7 @@ fn random_data_bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish();
 }
 
-fn random_increasing_data_sets_bench(c: &mut Criterion<CyclesPerByte>) {
+fn random_increasing_data_sets_bench(c: &mut Criterion<WallTime>) {
     let mut group = c.benchmark_group("Random Input Data Increasing");
 
     for size in [
@@ -120,7 +120,7 @@ fn random_increasing_data_sets_bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish()
 }
 
-fn repeating_increasing_data_sets_bench(c: &mut Criterion<CyclesPerByte>) {
+fn repeating_increasing_data_sets_bench(c: &mut Criterion<WallTime>) {
     let mut group = c.benchmark_group("Repeating Input Data Increasing");
 
     for size in [
@@ -139,7 +139,7 @@ fn repeating_increasing_data_sets_bench(c: &mut Criterion<CyclesPerByte>) {
     group.finish()
 }
 
-fn files_bench(c: &mut Criterion<CyclesPerByte>) {
+fn files_bench(c: &mut Criterion<WallTime>) {
     let mut entries = fs::read_dir("benches/bench_files/").unwrap()
         .map(|res| res.unwrap().path())
         .collect::<Vec<_>>();
@@ -165,7 +165,6 @@ fn files_bench(c: &mut Criterion<CyclesPerByte>) {
 criterion_group!(
     name = benches;
     config = Criterion::default()
-    .with_measurement(CyclesPerByte)
     .noise_threshold(0.02);
     targets = random_data_bench,
     random_increasing_data_sets_bench,

--- a/src/data/control/mod.rs
+++ b/src/data/control/mod.rs
@@ -147,6 +147,7 @@ impl Command {
     /// Get number of literal bytes on the command, if they have any
     /// Returns `None` if the length is 0
     #[must_use]
+    #[inline(always)]
     pub fn num_of_literal(self) -> Option<usize> {
         match self {
             Command::Short { literal, .. }
@@ -173,6 +174,7 @@ impl Command {
     ///
     /// Returns `None` if `self` is not a copy command.
     #[must_use]
+    #[inline(always)]
     pub fn offset_copy(self) -> Option<(usize, usize)> {
         match self {
             Command::Short { offset, length, .. } | Command::Medium { offset, length, .. } => {
@@ -185,6 +187,7 @@ impl Command {
 
     /// Returns true if the command is a stopcode, false if it is not.
     #[must_use]
+    #[inline(always)]
     pub fn is_stop(self) -> bool {
         matches!(self, Command::Stop(_))
     }

--- a/src/data/control/mod.rs
+++ b/src/data/control/mod.rs
@@ -26,21 +26,21 @@ use crate::{RefPackError, RefPackResult};
 pub enum Command {
     /// Represents a two byte copy command
     Short {
-        offset: u16,
-        length: u8,
         literal: u8,
+        length: u8,
+        offset: u16,
     },
     /// Represents a three byte copy command
     Medium {
-        offset: u16,
-        length: u8,
         literal: u8,
+        length: u8,
+        offset: u16,
     },
     /// Represents a four byte copy command
     Long {
-        offset: u32,
-        length: u16,
         literal: u8,
+        length: u16,
+        offset: u32,
     },
     /// Represents exclusively writing literal bytes from the stream
     ///
@@ -149,24 +149,17 @@ impl Command {
     #[must_use]
     #[inline(always)]
     pub fn num_of_literal(self) -> Option<usize> {
-        match self {
+        let num = match self {
             Command::Short { literal, .. }
             | Command::Medium { literal, .. }
-            | Command::Long { literal, .. } => {
-                if literal == 0 {
-                    None
-                } else {
-                    Some(literal as usize)
-                }
-            }
-            Command::Literal(number) => Some(number as usize),
-            Command::Stop(number) => {
-                if number == 0 {
-                    None
-                } else {
-                    Some(number as usize)
-                }
-            }
+            | Command::Long { literal, .. } => literal,
+            Command::Literal(literal) => literal,
+            Command::Stop(literal) => literal,
+        };
+        if num == 0 {
+            None
+        } else {
+            Some(num as usize)
         }
     }
 

--- a/src/data/control/mod.rs
+++ b/src/data/control/mod.rs
@@ -148,14 +148,13 @@ impl Command {
     /// Get number of literal bytes on the command, if they have any
     /// Returns `None` if the length is 0
     #[must_use]
-    #[inline(always)]
     pub fn num_of_literal(self) -> Option<usize> {
         let num = match self {
             Command::Short { literal, .. }
             | Command::Medium { literal, .. }
-            | Command::Long { literal, .. } => literal,
-            Command::Literal(literal) => literal,
-            Command::Stop(literal) => literal,
+            | Command::Long { literal, .. }
+            | Command::Literal(literal)
+            | Command::Stop(literal) => literal,
         };
         if num == 0 {
             None
@@ -168,7 +167,6 @@ impl Command {
     ///
     /// Returns `None` if `self` is not a copy command.
     #[must_use]
-    #[inline(always)]
     pub fn offset_copy(self) -> Option<(usize, usize)> {
         match self {
             Command::Short { offset, length, .. } | Command::Medium { offset, length, .. } => {
@@ -181,7 +179,6 @@ impl Command {
 
     /// Returns true if the command is a stopcode, false if it is not.
     #[must_use]
-    #[inline(always)]
     pub fn is_stop(self) -> bool {
         matches!(self, Command::Stop(_))
     }

--- a/src/data/control/mod.rs
+++ b/src/data/control/mod.rs
@@ -189,6 +189,7 @@ impl Command {
     /// # Errors
     /// Returns [RefPackError::Io](crate::RefPackError::Io) if a generic IO Error occurs while
     /// attempting to read data
+    #[inline(always)]
     pub fn read<M: Mode>(reader: &mut (impl Read + Seek)) -> RefPackResult<Self> {
         M::read(reader)
     }

--- a/src/data/control/mod.rs
+++ b/src/data/control/mod.rs
@@ -7,7 +7,8 @@
 
 //! control codes utilized by compression and decompression
 
-pub(crate) mod iterator;
+#[cfg(test)]
+mod iterator;
 pub mod mode;
 
 use std::io::{Read, Seek, Write};

--- a/src/data/control/mode/reference.rs
+++ b/src/data/control/mode/reference.rs
@@ -74,7 +74,7 @@ impl Reference {
     ///
     /// # Errors
     /// Returns [RefPackError::Io](crate::RefPackError::Io) if it fails to get the remaining one byte from the `reader`.
-    #[inline]
+    #[inline(always)]
     pub fn read_short(first: u8, reader: &mut (impl Read + Seek)) -> RefPackResult<Command> {
         let byte1 = first as usize;
         let byte2: usize = reader.read_u8()?.into();
@@ -94,7 +94,7 @@ impl Reference {
     ///
     /// # Errors
     /// Returns [RefPackError::Io](crate::RefPackError::Io) if it fails to get the remaining two bytes from the `reader`.
-    #[inline]
+    #[inline(always)]
     pub fn read_medium(first: u8, reader: &mut (impl Read + Seek)) -> RefPackResult<Command> {
         let byte1: usize = first as usize;
         let byte2: usize = reader.read_u8()?.into();
@@ -115,7 +115,7 @@ impl Reference {
     ///
     /// # Errors
     /// Returns [RefPackError::Io](crate::RefPackError::Io) if it fails to get the remaining three bytes from the `reader`.
-    #[inline]
+    #[inline(always)]
     pub fn read_long(first: u8, reader: &mut (impl Read + Seek)) -> RefPackResult<Command> {
         let byte1: usize = first as usize;
         let byte2: usize = reader.read_u8()?.into();
@@ -135,14 +135,14 @@ impl Reference {
     }
 
     /// Reference read implementation of literal commands. See [Reference] for specification
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn read_literal(first: u8) -> Command {
         Command::Literal(((first & 0b0001_1111) << 2) + 4)
     }
 
     /// Reference read implementation of stopcodes. See [Reference] for specification
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn read_stop(first: u8) -> Command {
         Command::Stop(first & 0b0000_0011)
@@ -258,6 +258,7 @@ impl Mode for Reference {
         long_length: (5, 1028),
     };
 
+    #[inline(always)]
     fn read<R: Read + Seek>(reader: &mut R) -> RefPackResult<Command> {
         let first = reader.read_u8()?;
 

--- a/src/data/control/mode/simcity_4.rs
+++ b/src/data/control/mode/simcity_4.rs
@@ -43,6 +43,7 @@ impl Mode for Simcity4 {
         long_length: Reference::SIZES.long_length,
     };
 
+    #[inline(always)]
     fn read<R: Read + Seek>(reader: &mut R) -> Result<Command, RefPackError> {
         let first = reader.read_u8()?;
 

--- a/src/data/decompression.rs
+++ b/src/data/decompression.rs
@@ -6,7 +6,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Decompression parsing, algorithms, and functionality
-use std::io::{Cursor, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::io::{Cursor, Read, Seek, Write};
 
 use crate::data::control::Command;
 use crate::data::{copy_from_reader, rle_decode_fixed};

--- a/src/data/decompression.rs
+++ b/src/data/decompression.rs
@@ -28,7 +28,7 @@ fn decompress_internal<F: Format>(
     let mut decompression_buffer = vec![0; decompressed_length as usize];
     let mut position = 0usize;
 
-    while {
+    loop {
         let command = Command::read::<F::ControlMode>(reader)?;
 
         match command {
@@ -56,7 +56,6 @@ fn decompress_internal<F: Format>(
                     offset as usize,
                     length as usize,
                 )?;
-                true
             }
             Command::Long {
                 offset,
@@ -77,7 +76,6 @@ fn decompress_internal<F: Format>(
                     offset as usize,
                     length as usize,
                 )?;
-                true
             }
             Command::Literal(literal) => {
                 position = copy_from_reader(
@@ -86,7 +84,6 @@ fn decompress_internal<F: Format>(
                     position,
                     literal as usize,
                 )?;
-                true
             }
             Command::Stop(literal) => {
                 copy_from_reader(
@@ -95,10 +92,10 @@ fn decompress_internal<F: Format>(
                     position,
                     literal as usize,
                 )?;
-                false
+                break;
             }
         }
-    } {}
+    }
 
     Ok(decompression_buffer)
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -9,6 +9,7 @@
 //! the actual compression algorithms themselves, control codes, etc.
 
 use std::io::{Read, Seek};
+
 use crate::RefPackError;
 
 pub mod compression;
@@ -38,8 +39,11 @@ pub(crate) fn rle_decode_fixed<T>(
     buffer: &mut [T],
     mut position: usize,
     mut offset: usize,
-    mut length: usize) -> Result<usize, RefPackError>
-    where T: Copy {
+    mut length: usize,
+) -> Result<usize, RefPackError>
+where
+    T: Copy,
+{
     if offset == 0 {
         return Err(RefPackError::BadOffset);
     }
@@ -59,7 +63,10 @@ pub(crate) fn rle_decode_fixed<T>(
         offset *= 2;
     }
 
-    buffer.copy_within(copy_fragment_start..(copy_fragment_start + length), position);
+    buffer.copy_within(
+        copy_fragment_start..(copy_fragment_start + length),
+        position,
+    );
     position += length;
 
     Ok(position)
@@ -78,7 +85,8 @@ pub(crate) fn copy_from_reader(
     buffer: &mut [u8],
     reader: &mut (impl Read + Seek),
     position: usize,
-    length: usize) -> Result<usize, RefPackError> {
+    length: usize,
+) -> Result<usize, RefPackError> {
     if position + length > buffer.len() {
         return Err(RefPackError::BadLength(position + length - buffer.len()));
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -50,9 +50,7 @@ pub(crate) fn rle_decode_fixed<T>(
         return Err(RefPackError::BadLength(position + length - buffer.len()));
     }
 
-    let copy_fragment_start = position
-        .checked_sub(offset)
-        .ok_or_else(|| RefPackError::NegativePosition(position, offset))?;
+    let copy_fragment_start = position - offset;
 
     while length > offset {
         buffer.copy_within(copy_fragment_start..position, position);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn rle_decode<T>(
 
     let copy_fragment_start = buffer.len()
         .checked_sub(lookbehind_length)
-        .ok_or_else(|| RefPackError::BadOffset(buffer.len(), lookbehind_length))?;
+        .ok_or_else(|| RefPackError::NegativePosition(buffer.len(), lookbehind_length))?;
 
     // we don't need to reserve here because refpack has a decoded_length reserve
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,6 +8,7 @@
 //! things relating the actual compressed data block. Anything past the header info,
 //! the actual compression algorithms themselves, control codes, etc.
 
+use std::io::{Read, Seek};
 use crate::RefPackError;
 
 pub mod compression;
@@ -17,49 +18,76 @@ pub mod decompression;
 /// Fast decoding of run length encoded data
 /// Based on https://github.com/WanzenBug/rle-decode-helper/blob/master/src/lib.rs
 ///
-/// Takes the last `lookbehind_length` items of the buffer and repeatedly appends them until
-/// `fill_length` items have been copied.
+/// Takes the last `offset` items of the buffer and repeatedly copies them
+/// to `position` until `length` items have been copied.
 ///
 /// If this function errors no data will have been copied
 ///
 /// # Errors
-/// * `lookbehind_length` is 0
-/// * `lookbehind_length` >= `buffer.len()`
+/// * `offset` is 0
+/// * `offset` > `position`
+/// * `position + length` > `buffer.len()`
 ///
 /// # Panics
 /// * `fill_length + buffer.len()` would overflow
+///
+/// # Returns
+/// * the new position of the buffer after the read
 #[inline(always)]
-pub(crate) fn rle_decode<T>(
-    buffer: &mut Vec<T>,
-    mut lookbehind_length: usize,
-    mut fill_length: usize,
-) -> Result<(), RefPackError> where T: Copy  {
-    if lookbehind_length == 0 {
+pub(crate) fn rle_decode_fixed<T>(
+    buffer: &mut [T],
+    mut position: usize,
+    mut offset: usize,
+    mut length: usize) -> Result<usize, RefPackError>
+    where T: Copy {
+    if offset == 0 {
         return Err(RefPackError::BadOffset);
     }
-
-    let copy_fragment_start = buffer.len()
-        .checked_sub(lookbehind_length)
-        .ok_or_else(|| RefPackError::NegativePosition(buffer.len(), lookbehind_length))?;
-
-    // we don't need to reserve here because refpack has a decoded_length reserve
-
-    // if fill_length == lookbehind_length, do only one call to extend_from_within so don't loop
-    // (prevents call with (buffer, copy_fragment_start..copy_fragment_start) which does nothing)
-    while fill_length > lookbehind_length {
-        buffer.extend_from_within(
-            copy_fragment_start..(copy_fragment_start + lookbehind_length)
-        );
-        fill_length -= lookbehind_length;
-        lookbehind_length *= 2;
+    if offset > position {
+        return Err(RefPackError::NegativePosition(position, offset));
+    }
+    if position + length > buffer.len() {
+        return Err(RefPackError::BadLength(position + length - buffer.len()));
     }
 
-    // Copy the last remaining bytes
-    buffer.extend_from_within(
-        copy_fragment_start..(copy_fragment_start + fill_length),
-    );
+    let copy_fragment_start = position
+        .checked_sub(offset)
+        .ok_or_else(|| RefPackError::NegativePosition(position, offset))?;
 
-    Ok(())
+    while length > offset {
+        buffer.copy_within(copy_fragment_start..position, position);
+        length -= offset;
+        position += offset;
+        offset *= 2;
+    }
+
+    buffer.copy_within(copy_fragment_start..(copy_fragment_start + length), position);
+    position += length;
+
+    Ok(position)
+}
+
+/// Copy `length` bytes from the reader into `buffer` at `position`
+///
+/// # Errors
+/// * `position + length` > `buffer.len()`
+/// * General IO error
+///
+/// # Returns
+/// * the new position of the buffer after the read
+#[inline(always)]
+pub(crate) fn copy_from_reader(
+    buffer: &mut [u8],
+    reader: &mut (impl Read + Seek),
+    position: usize,
+    length: usize) -> Result<usize, RefPackError> {
+    if position + length > buffer.len() {
+        return Err(RefPackError::BadLength(position + length - buffer.len()));
+    }
+
+    reader.read_exact(&mut buffer[position..(position + length)])?;
+
+    Ok(position + length)
 }
 
 #[cfg(test)]
@@ -71,7 +99,7 @@ mod test {
     use crate::{easy_compress, easy_decompress};
 
     #[proptest(ProptestConfig { cases: 100_000, ..Default::default() })]
-    fn symmetrical_compression(#[filter(#input.len() > 0)] input: Vec<u8>) {
+    fn symmetrical_compression(#[filter(# input.len() > 0)] input: Vec<u8>) {
         let compressed = easy_compress::<Reference>(&input).unwrap();
         let decompressed = easy_decompress::<Reference>(&compressed).unwrap();
 
@@ -83,7 +111,7 @@ mod test {
     ..Default::default()
     })]
     fn symmetrical_compression_large_input(
-        #[strategy(proptest::collection::vec(any::<u8>(), (2_000..=2_000)))] input: Vec<u8>,
+        #[strategy(proptest::collection::vec(any::< u8 > (), (2_000..=2_000)))] input: Vec<u8>,
     ) {
         let compressed = easy_compress::<Reference>(&input).unwrap();
         let decompressed = easy_decompress::<Reference>(&compressed).unwrap();

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,18 +8,58 @@
 //! things relating the actual compressed data block. Anything past the header info,
 //! the actual compression algorithms themselves, control codes, etc.
 
+use crate::RefPackError;
+
 pub mod compression;
 pub mod control;
 pub mod decompression;
 
-pub(crate) fn copy_within_slice(v: &mut [impl Copy], from: usize, to: usize, len: usize) {
-    if from > to {
-        let (dst, src) = v.split_at_mut(from);
-        dst[to..to + len].copy_from_slice(&src[..len]);
-    } else {
-        let (src, dst) = v.split_at_mut(to);
-        dst[..len].copy_from_slice(&src[from..from + len]);
+/// Fast decoding of run length encoded data
+/// Based on https://github.com/WanzenBug/rle-decode-helper/blob/master/src/lib.rs
+///
+/// Takes the last `lookbehind_length` items of the buffer and repeatedly appends them until
+/// `fill_length` items have been copied.
+///
+/// If this function errors no data will have been copied
+///
+/// # Errors
+/// * `lookbehind_length` is 0
+/// * `lookbehind_length` >= `buffer.len()`
+///
+/// # Panics
+/// * `fill_length + buffer.len()` would overflow
+#[inline(always)]
+pub(crate) fn rle_decode<T>(
+    buffer: &mut Vec<T>,
+    mut lookbehind_length: usize,
+    mut fill_length: usize,
+) -> Result<(), RefPackError> where T: Copy  {
+    if lookbehind_length == 0 {
+        return Err(RefPackError::BadOffset);
     }
+
+    let copy_fragment_start = buffer.len()
+        .checked_sub(lookbehind_length)
+        .ok_or_else(|| RefPackError::BadOffset(buffer.len(), lookbehind_length))?;
+
+    // we don't need to reserve here because refpack has a decoded_length reserve
+
+    // if fill_length == lookbehind_length, do only one call to extend_from_within so don't loop
+    // (prevents call with (buffer, copy_fragment_start..copy_fragment_start) which does nothing)
+    while fill_length > lookbehind_length {
+        buffer.extend_from_within(
+            copy_fragment_start..(copy_fragment_start + lookbehind_length)
+        );
+        fill_length -= lookbehind_length;
+        lookbehind_length *= 2;
+    }
+
+    // Copy the last remaining bytes
+    buffer.extend_from_within(
+        copy_fragment_start..(copy_fragment_start + fill_length),
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,19 @@ pub enum Error {
     /// u16: What was read instead of the magic value
     #[error("Invalid magic number at compression header `{0:#04X}`")]
     BadMagic(u8),
+    /// Error indicating that offset was 0 in refpack control byte
+    /// this is generally only possible in the Simcity4 data control mode
+    #[error("Offset is 0 in compressed data control command")]
+    BadOffset,
+    /// Error indicating that the requested copy offset was larger than the length of the buffer to copy from
+    /// this means that the copy function would try to copy
+    /// from before the start of the buffer which is an illegal operation
+    #[error("Offset went past start of buffer: buffer length `{0}`, offset `{1}`")]
+    NegativePosition(usize, usize),
+    /// Indicates that the decompressed file would be larger than the indicated size in the header
+    /// this is important to prevent accidental massive memory usage
+    #[error("Decompressed data is larger than decompressed size in header by `{0}` bytes")]
+    BadLength(usize),
     /// Generic IO Error wrapper for when a generic IO error of some sort occurs in relation to
     /// the readers and writers.
     #[error("IO Error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@
 #![allow(clippy::too_many_lines)]
 // causes weirdness with header and reader
 #![allow(clippy::similar_names)]
+// all uses of #[inline(always)] have been benchmarked thoroughly
+#![allow(clippy::inline_always)]
 
 pub mod data;
 mod error;


### PR DESCRIPTION
Improves performance of the decompression algorithm on real-world data 250-400%

[bench.txt](https://github.com/actioninja/refpack-rs/files/11105260/bench.txt)

Some of the highlights:

- use `&mut [T].copy_within()` in a recursive way (+7-1000% depending on data)
- copy directly from input to read buffer without intermediate `Vec` allocation (+200-300%)
- inlining (+25-50%)
- match on `Command` returned from `read` (+5-10%)

Overall, right now this is good enough for my use case (reading at ~600MiB/s) so I feel doing any more optimization would only be detrimental (in terms of development time and readability).

Sadly these changes make a bunch of the functions obsolete, so there is a question about if they should remain or be removed:

- I believe right now this repository is the most complete and comprehensive source of information about the RefPack format, and removing the code would take away from that comprehensiveness.
- The code is also still used in tests that might safeguard against regressions.

However:
- These functions are no longer used outside of tests and are in effect useless for user of the library. (should they be marked `[cfg(test)]`?)

After a cursory look at the compress implementation I've also spotted some performance improvements there, but right now I don't personally need write performance (and write performance is less critical in general) so I will leave it as is for the moment.